### PR TITLE
Fix Docker build error - remove shell syntax from COPY command

### DIFF
--- a/aisheets/Dockerfile
+++ b/aisheets/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 # we'll create a custom spreadsheet interface
 
 # Copy package.json for the web app
-COPY package.json /app/package.json 2>/dev/null || true
+COPY package.json /app/package.json
 
 # Create a simple Brain Cells web interface
 RUN mkdir -p /app/public /app/src /app/config


### PR DESCRIPTION
The Docker COPY instruction doesn't support shell syntax like '2>/dev/null || true' This was causing the build to fail with:
  "failed to compute cache key: '/||': not found"

Fixed by removing the shell operators from line 17 of the Dockerfile. The package.json file exists, so the plain COPY command works correctly.

Build now succeeds with:
  docker compose build
  docker compose up -d