### PR TITLE
Remove login button and update branding to Brain Cells

### DIFF
--- a/aisheets/src/routes/home/dataset/[id]/index.tsx
+++ b/aisheets/src/routes/home/dataset/[id]/index.tsx
@@ -4,7 +4,6 @@ import type {
   RequestEvent,
   RequestHandler,
 } from '@builder.io/qwik-city';
-import { Login } from '~/components/ui/login/Login';
 import { MobileBanner } from '~/components/ui/mobile/banner';
 import { Tips } from '~/components/ui/tips/tips';
 import { DatasetName } from '~/features/datasets';
@@ -41,7 +40,7 @@ export default component$(() => {
                 <DatasetName />
                 <SaveDataset />
               </div>
-              {session.value.anonymous ? <Login /> : <Username />}
+              {!session.value.anonymous && <Username />}
             </div>
           </div>
         </div>

--- a/aisheets/src/routes/home/index.tsx
+++ b/aisheets/src/routes/home/index.tsx
@@ -214,9 +214,9 @@ export default component$(() => {
 
         <div class="flex items-center gap-2">
           <BigTips>
-            <h1 class="font-semibold text-xl">What is Sheets?</h1>
+            <h1 class="font-semibold text-xl">About Brain Cells</h1>
             <p>
-              Sheets is a tool to build and transform structured tables using AI
+              Brain Cells is a tool to build and transform structured tables using AI
               and web search. You can build tables from scratch or augment your
               own spreadsheets by:
             </p>
@@ -228,7 +228,7 @@ export default component$(() => {
               <li>Using different open models</li>
               <li>Editing individual cells</li>
             </ul>
-            <h1 class="font-semibold text-xl">How can Sheets help you?</h1>
+            <h1 class="font-semibold text-xl">How can Brain Cells help you?</h1>
             <ul class="space-y-3">
               <li>
                 <b>Enrich Datasets with AI and the Web:</b> Automatically
@@ -303,7 +303,7 @@ export default component$(() => {
               </li>
               <li>
                 <b>Hundreds of models</b> Powered by Hugging Face Inference
-                Providers, Sheets provides access to the latest models and the
+                Providers, Brain Cells provides access to the latest models and the
                 fastest inference providers.
               </li>
               <li>


### PR DESCRIPTION
- Remove login button from dataset page
- Update "What is Sheets?" to "About Brain Cells"
- Replace all instances of "Sheets" with "Brain Cells" in home page modal