### PR TITLE
Add Mercury 2 (Inception Labs) as alternative AI provider

### DIFF
--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -13,14 +13,30 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { toast } from 'sonner';
 import { useOpenAIKey } from '@/hooks/use-openai-key';
+import type { Provider } from '@/lib/types/domain';
+
+const PROVIDERS: { value: Provider; label: string; description: string; placeholder: string }[] = [
+  {
+    value: 'openai',
+    label: 'OpenAI',
+    description: 'GPT-4o, GPT-4.1, o4-mini, and more',
+    placeholder: 'sk-...',
+  },
+  {
+    value: 'mercury',
+    label: 'Mercury (Inception Labs)',
+    description: 'Diffusion-based LLM — 5-10x faster, $0.25/M input tokens',
+    placeholder: 'sk_...',
+  },
+];
 
 export default function SettingsPage() {
-  const { apiKey, setApiKey, clearApiKey, isLoaded, hasKey } = useOpenAIKey();
+  const { provider, setProvider, apiKey, setApiKey, clearApiKey, isLoaded, hasKey } =
+    useOpenAIKey();
   const [keyInput, setKeyInput] = useState('');
 
   useEffect(() => {
     if (isLoaded && apiKey) {
-      // Show masked key
       setKeyInput(apiKey.slice(0, 7) + '...' + apiKey.slice(-4));
     }
   }, [isLoaded, apiKey]);
@@ -41,18 +57,70 @@ export default function SettingsPage() {
     toast.success('API key removed');
   };
 
+  const handleProviderChange = (p: Provider) => {
+    setProvider(p);
+    // Clear key input when switching providers since keys differ
+    if (apiKey) {
+      clearApiKey();
+      setKeyInput('');
+    }
+  };
+
+  const currentProvider = PROVIDERS.find((p) => p.value === provider)!;
+
   return (
     <div className="mx-auto max-w-2xl px-6 py-10">
       <h1 className="text-2xl font-bold text-zinc-100 mb-6">Settings</h1>
 
       <Card className="border-zinc-800 bg-zinc-900">
         <CardHeader>
+          <CardTitle className="text-lg text-zinc-100">AI Provider</CardTitle>
+          <CardDescription className="text-zinc-500">
+            Choose which AI provider to use for generation.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {PROVIDERS.map((p) => (
+            <button
+              key={p.value}
+              onClick={() => handleProviderChange(p.value)}
+              className={`w-full text-left rounded-lg border p-3 transition-colors ${
+                provider === p.value
+                  ? 'border-blue-500 bg-blue-500/10'
+                  : 'border-zinc-700 bg-zinc-800 hover:border-zinc-600'
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <div
+                  className={`h-2 w-2 rounded-full ${
+                    provider === p.value ? 'bg-blue-500' : 'bg-zinc-600'
+                  }`}
+                />
+                <span className="text-sm font-medium text-zinc-100">
+                  {p.label}
+                </span>
+              </div>
+              <p className="mt-1 ml-4 text-xs text-zinc-500">{p.description}</p>
+            </button>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Separator className="my-6 bg-zinc-800" />
+
+      <Card className="border-zinc-800 bg-zinc-900">
+        <CardHeader>
           <CardTitle className="text-lg text-zinc-100">
-            OpenAI API Key
+            {currentProvider.label} API Key
           </CardTitle>
           <CardDescription className="text-zinc-500">
             Your API key is stored locally in your browser and sent with each
             request. It is never stored on our servers.
+            {provider === 'mercury' && (
+              <span className="block mt-1 text-zinc-600">
+                Base URL: https://api.inceptionlabs.ai/v1
+              </span>
+            )}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -61,7 +129,7 @@ export default function SettingsPage() {
               type="text"
               value={keyInput}
               onChange={(e) => setKeyInput(e.target.value)}
-              placeholder="sk-..."
+              placeholder={currentProvider.placeholder}
               className="border-zinc-700 bg-zinc-800 text-zinc-100 font-mono text-sm"
               onFocus={() => {
                 if (keyInput.includes('...')) setKeyInput('');
@@ -98,30 +166,31 @@ export default function SettingsPage() {
           <CardDescription className="text-zinc-500">
             braincells is a spreadsheet where columns can be AI-generated.
             Reference data between columns using {'{{column_name}}'} syntax
-            in your prompts to create powerful data pipelines.
+            in your prompts to create powerful data pipelines. Supports OpenAI
+            and Mercury (Inception Labs) models.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-2 text-sm text-zinc-400">
             <p>
               <strong className="text-zinc-300">Text Generation</strong> —
-              Generate text using GPT models
+              Generate text using GPT or Mercury models
             </p>
             <p>
               <strong className="text-zinc-300">Image Generation</strong> —
-              Create images from text descriptions
+              Create images from text descriptions (OpenAI only)
             </p>
             <p>
               <strong className="text-zinc-300">Vision</strong> — Analyze
-              images and generate text descriptions
+              images and generate text descriptions (OpenAI only)
             </p>
             <p>
               <strong className="text-zinc-300">Speech</strong> — Convert
-              text to audio
+              text to audio (OpenAI only)
             </p>
             <p>
               <strong className="text-zinc-300">Transcription</strong> —
-              Convert audio to text
+              Convert audio to text (OpenAI only)
             </p>
           </div>
         </CardContent>

--- a/src/app/api/autodataset/route.ts
+++ b/src/app/api/autodataset/route.ts
@@ -11,18 +11,20 @@ import { extractColumnReferences } from '@/lib/utils/prompt-template';
 import { createColumn, getMaxPosition } from '@/lib/supabase/queries/columns';
 import { createDataset } from '@/lib/supabase/queries/datasets';
 import { upsertProcess } from '@/lib/supabase/queries/processes';
-import { DEFAULT_MODEL } from '@/lib/types/domain';
-import type { TaskType } from '@/lib/types/domain';
+import { DEFAULT_MODEL, MERCURY_BASE_URL } from '@/lib/types/domain';
+import type { TaskType, Provider } from '@/lib/types/domain';
 
 export const maxDuration = 300;
 
 export async function POST(request: NextRequest) {
-  const apiKey = request.headers.get('x-openai-api-key');
+  const apiKey = request.headers.get('x-api-key') || request.headers.get('x-openai-api-key');
   if (!apiKey) {
-    return new Response(JSON.stringify({ error: 'Missing OpenAI API key' }), {
+    return new Response(JSON.stringify({ error: 'Missing API key' }), {
       status: 401,
     });
   }
+  const provider = (request.headers.get('x-ai-provider') || 'openai') as Provider;
+  const baseURL = provider === 'mercury' ? MERCURY_BASE_URL : undefined;
 
   const {
     instruction,
@@ -31,7 +33,7 @@ export async function POST(request: NextRequest) {
   } = await request.json();
 
   const supabase = await createClient();
-  const openai = createOpenAIClient(apiKey);
+  const openai = createOpenAIClient(apiKey, baseURL);
 
   const {
     data: { user },
@@ -180,7 +182,8 @@ export async function POST(request: NextRequest) {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              'x-openai-api-key': apiKey,
+              'x-api-key': apiKey,
+              'x-ai-provider': provider,
               Cookie: request.headers.get('cookie') || '',
             },
             body: JSON.stringify({

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -14,8 +14,8 @@ import {
 } from '@/lib/utils/prompt-template';
 import { upsertCellValue, getRowCells } from '@/lib/supabase/queries/cells';
 import { upsertCellMeta } from '@/lib/supabase/queries/cell-meta';
-import type { TaskType } from '@/lib/types/domain';
-import { MAX_CONCURRENCY } from '@/lib/types/domain';
+import type { TaskType, Provider } from '@/lib/types/domain';
+import { MAX_CONCURRENCY, MERCURY_BASE_URL } from '@/lib/types/domain';
 
 export const maxDuration = 300;
 
@@ -36,13 +36,15 @@ interface GenerateRequest {
 }
 
 export async function POST(request: NextRequest) {
-  const apiKey = request.headers.get('x-openai-api-key');
+  const apiKey = request.headers.get('x-api-key') || request.headers.get('x-openai-api-key');
   if (!apiKey) {
     return new Response(
-      JSON.stringify({ error: 'Missing OpenAI API key' }),
+      JSON.stringify({ error: 'Missing API key' }),
       { status: 401 },
     );
   }
+  const provider = (request.headers.get('x-ai-provider') || 'openai') as Provider;
+  const baseURL = provider === 'mercury' ? MERCURY_BASE_URL : undefined;
 
   const body: GenerateRequest = await request.json();
   const {
@@ -65,7 +67,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const openai = createOpenAIClient(apiKey);
+  const openai = createOpenAIClient(apiKey, baseURL);
 
   const encoder = new TextEncoder();
   const stream = new ReadableStream({

--- a/src/components/dataset/autodataset-wizard.tsx
+++ b/src/components/dataset/autodataset-wizard.tsx
@@ -33,7 +33,7 @@ export function AutoDatasetWizard({
   const [running, setRunning] = useState(false);
   const [steps, setSteps] = useState<WizardStep[]>([]);
   const [error, setError] = useState('');
-  const { apiKey, hasKey } = useOpenAIKey();
+  const { apiKey, hasKey, provider } = useOpenAIKey();
 
   const handleRun = async () => {
     if (!instruction.trim() || !hasKey) return;
@@ -48,7 +48,8 @@ export function AutoDatasetWizard({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-openai-api-key': apiKey,
+          'x-api-key': apiKey,
+          'x-ai-provider': provider,
         },
         body: JSON.stringify({
           instruction: instruction.trim(),

--- a/src/components/sidebar/process-form.tsx
+++ b/src/components/sidebar/process-form.tsx
@@ -17,15 +17,20 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { toast } from 'sonner';
-import type { Column, TaskType } from '@/lib/types/domain';
+import type { Column, TaskType, Provider } from '@/lib/types/domain';
 
 const MODELS = [
-  { value: 'gpt-4o-mini', label: 'GPT-4o Mini' },
-  { value: 'gpt-4o', label: 'GPT-4o' },
-  { value: 'gpt-4.1', label: 'GPT-4.1' },
-  { value: 'gpt-4.1-mini', label: 'GPT-4.1 Mini' },
-  { value: 'gpt-image-1', label: 'GPT Image 1' },
-  { value: 'o4-mini', label: 'o4-mini' },
+  // OpenAI
+  { value: 'gpt-4o-mini', label: 'GPT-4o Mini', provider: 'openai' as const },
+  { value: 'gpt-4o', label: 'GPT-4o', provider: 'openai' as const },
+  { value: 'gpt-4.1', label: 'GPT-4.1', provider: 'openai' as const },
+  { value: 'gpt-4.1-mini', label: 'GPT-4.1 Mini', provider: 'openai' as const },
+  { value: 'gpt-image-1', label: 'GPT Image 1', provider: 'openai' as const },
+  { value: 'o4-mini', label: 'o4-mini', provider: 'openai' as const },
+  // Mercury (Inception Labs)
+  { value: 'mercury-2', label: 'Mercury 2', provider: 'mercury' as const },
+  { value: 'mercury-coder', label: 'Mercury Coder', provider: 'mercury' as const },
+  { value: 'mercury-edit', label: 'Mercury Edit', provider: 'mercury' as const },
 ];
 
 const TASKS: { value: TaskType; label: string }[] = [
@@ -36,18 +41,28 @@ const TASKS: { value: TaskType; label: string }[] = [
   { value: 'transcription', label: 'Transcription' },
 ];
 
+// Tasks that Mercury does not support (text-only model)
+const MERCURY_UNSUPPORTED_TASKS: TaskType[] = [
+  'text-to-image',
+  'image-text-to-text',
+  'speech',
+  'transcription',
+];
+
 export function ProcessForm({
   column,
   columns,
   datasetId,
   apiKey,
+  provider,
 }: {
   column: Column;
   columns: Column[];
   datasetId: string;
   apiKey: string;
+  provider: Provider;
 }) {
-  const { updateColumnProcess, updateCell, setRowCount, rowCount } =
+  const { updateColumnProcess, updateCell, setRowCount } =
     useDatasetStore();
   const { setSelectedColumnId, setIsGenerating, setGeneratingColumnId } =
     useUIStore();
@@ -65,6 +80,27 @@ export function ProcessForm({
   );
   const [generating, setGenerating] = useState(false);
   const [rowLimit, setRowLimit] = useState(5);
+
+  const availableModels = MODELS.filter((m) => m.provider === provider);
+
+  // When provider changes, reset model to a valid one for that provider
+  useEffect(() => {
+    const modelBelongsToProvider = availableModels.some((m) => m.value === model);
+    if (!modelBelongsToProvider) {
+      setModel(availableModels[0]?.value || 'gpt-4o-mini');
+    }
+  }, [provider]);
+
+  // When provider is mercury and task is unsupported, reset to text-generation
+  useEffect(() => {
+    if (provider === 'mercury' && MERCURY_UNSUPPORTED_TASKS.includes(task)) {
+      setTask('text-generation');
+    }
+    // Disable web search for mercury (uses OpenAI Responses API)
+    if (provider === 'mercury' && searchEnabled) {
+      setSearchEnabled(false);
+    }
+  }, [provider]);
 
   useEffect(() => {
     setPrompt(column.process?.prompt || '');
@@ -141,7 +177,7 @@ export function ProcessForm({
 
   const handleGenerate = async () => {
     if (!apiKey) {
-      toast.error('Set your OpenAI API key in Settings');
+      toast.error('Set your API key in Settings');
       return;
     }
 
@@ -165,7 +201,8 @@ export function ProcessForm({
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-openai-api-key': apiKey,
+          'x-api-key': apiKey,
+          'x-ai-provider': provider,
         },
         body: JSON.stringify({
           dataset_id: datasetId,
@@ -259,6 +296,7 @@ export function ProcessForm({
   );
   const needsImageColumn =
     task === 'image-text-to-text' || task === 'transcription';
+  const isMercury = provider === 'mercury';
 
   return (
     <div className="p-4 space-y-5">
@@ -285,18 +323,26 @@ export function ProcessForm({
           onValueChange={(v) => {
             setTask(v as TaskType);
             if (v === 'text-to-image') setModel('gpt-image-1');
-            else if (model === 'gpt-image-1') setModel('gpt-4o-mini');
+            else if (model === 'gpt-image-1') setModel(availableModels[0]?.value || 'gpt-4o-mini');
           }}
         >
           <SelectTrigger className="border-zinc-700 bg-zinc-800 text-zinc-100 text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {TASKS.map((t) => (
-              <SelectItem key={t.value} value={t.value}>
-                {t.label}
-              </SelectItem>
-            ))}
+            {TASKS.map((t) => {
+              const disabled = isMercury && MERCURY_UNSUPPORTED_TASKS.includes(t.value);
+              return (
+                <SelectItem
+                  key={t.value}
+                  value={t.value}
+                  disabled={disabled}
+                >
+                  {t.label}
+                  {disabled && ' (OpenAI only)'}
+                </SelectItem>
+              );
+            })}
           </SelectContent>
         </Select>
       </div>
@@ -308,7 +354,7 @@ export function ProcessForm({
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            {MODELS.map((m) => (
+            {availableModels.map((m) => (
               <SelectItem key={m.value} value={m.value}>
                 {m.label}
               </SelectItem>
@@ -368,7 +414,7 @@ export function ProcessForm({
         </div>
       )}
 
-      {task === 'text-generation' && (
+      {task === 'text-generation' && !isMercury && (
         <div className="flex items-center gap-2">
           <Checkbox
             id="search"

--- a/src/components/table/spreadsheet.tsx
+++ b/src/components/table/spreadsheet.tsx
@@ -30,7 +30,7 @@ export function Spreadsheet({
     mergeCells,
   } = useDatasetStore();
   const { sidebarOpen, selectedColumnId } = useUIStore();
-  const { apiKey, hasKey } = useOpenAIKey();
+  const { apiKey, hasKey, provider } = useOpenAIKey();
   const [initialLoad, setInitialLoad] = useState(true);
 
   useRealtimeCells(dataset.id);
@@ -198,6 +198,7 @@ export function Spreadsheet({
               columns={columns}
               datasetId={dataset.id}
               apiKey={apiKey}
+              provider={provider}
             />
           </div>
         )}

--- a/src/hooks/use-openai-key.ts
+++ b/src/hooks/use-openai-key.ts
@@ -1,28 +1,63 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import type { Provider } from '@/lib/types/domain';
+import { MERCURY_BASE_URL } from '@/lib/types/domain';
 
-const STORAGE_KEY = 'openai-api-key';
+const PROVIDER_KEY = 'ai-provider';
+const API_KEY_KEY = 'ai-api-key';
+const LEGACY_KEY = 'openai-api-key';
 
 export function useOpenAIKey() {
+  const [provider, setProviderState] = useState<Provider>('openai');
   const [apiKey, setApiKeyState] = useState<string>('');
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) setApiKeyState(stored);
+    // Migrate from legacy storage
+    const legacyKey = localStorage.getItem(LEGACY_KEY);
+    const storedProvider = localStorage.getItem(PROVIDER_KEY) as Provider | null;
+    const storedKey = localStorage.getItem(API_KEY_KEY);
+
+    if (legacyKey && !storedKey) {
+      // Migrate: move legacy key to new storage
+      localStorage.setItem(API_KEY_KEY, legacyKey);
+      localStorage.setItem(PROVIDER_KEY, 'openai');
+      localStorage.removeItem(LEGACY_KEY);
+      setProviderState('openai');
+      setApiKeyState(legacyKey);
+    } else {
+      if (storedProvider) setProviderState(storedProvider);
+      if (storedKey) setApiKeyState(storedKey);
+    }
     setIsLoaded(true);
   }, []);
 
+  const setProvider = useCallback((p: Provider) => {
+    localStorage.setItem(PROVIDER_KEY, p);
+    setProviderState(p);
+  }, []);
+
   const setApiKey = useCallback((key: string) => {
-    localStorage.setItem(STORAGE_KEY, key);
+    localStorage.setItem(API_KEY_KEY, key);
     setApiKeyState(key);
   }, []);
 
   const clearApiKey = useCallback(() => {
-    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(API_KEY_KEY);
     setApiKeyState('');
   }, []);
 
-  return { apiKey, setApiKey, clearApiKey, isLoaded, hasKey: !!apiKey };
+  const baseURL = provider === 'mercury' ? MERCURY_BASE_URL : undefined;
+
+  return {
+    provider,
+    setProvider,
+    apiKey,
+    setApiKey,
+    clearApiKey,
+    isLoaded,
+    hasKey: !!apiKey,
+    baseURL,
+  };
 }

--- a/src/lib/openai/client.ts
+++ b/src/lib/openai/client.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
 
-export function createOpenAIClient(apiKey: string): OpenAI {
-  return new OpenAI({ apiKey });
+export function createOpenAIClient(apiKey: string, baseURL?: string): OpenAI {
+  return new OpenAI({ apiKey, ...(baseURL && { baseURL }) });
 }

--- a/src/lib/openai/text-generation.ts
+++ b/src/lib/openai/text-generation.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import type { ChatCompletionCreateParamsNonStreaming, ChatCompletionCreateParamsStreaming } from 'openai/resources/chat/completions';
 
 export async function generateText(
   client: OpenAI,
@@ -6,10 +7,12 @@ export async function generateText(
   model = 'gpt-4o-mini',
 ): Promise<{ value?: string; error?: string }> {
   try {
-    const response = await client.chat.completions.create({
+    const params: ChatCompletionCreateParamsNonStreaming = {
       model,
       messages: [{ role: 'user', content: prompt }],
-    });
+      ...(model.startsWith('mercury') && { realtime: true } as any),
+    };
+    const response = await client.chat.completions.create(params);
 
     const content = response.choices[0]?.message?.content;
     return { value: content || '' };
@@ -24,11 +27,13 @@ export async function* streamText(
   prompt: string,
   model = 'gpt-4o-mini',
 ): AsyncGenerator<{ value: string; done: boolean }> {
-  const stream = await client.chat.completions.create({
+  const params: ChatCompletionCreateParamsStreaming = {
     model,
     messages: [{ role: 'user', content: prompt }],
     stream: true,
-  });
+    ...(model.startsWith('mercury') && { realtime: true } as any),
+  };
+  const stream = await client.chat.completions.create(params);
 
   let accumulated = '';
   for await (const chunk of stream) {

--- a/src/lib/types/domain.ts
+++ b/src/lib/types/domain.ts
@@ -64,6 +64,10 @@ export interface AutoDatasetConfig {
   text: string;
 }
 
+export type Provider = 'openai' | 'mercury';
+
+export const MERCURY_BASE_URL = 'https://api.inceptionlabs.ai/v1';
+
 export const DEFAULT_MODEL = 'gpt-4o-mini';
 export const MAX_CONCURRENCY = 5;
 export const EXAMPLES_PROMPT_MAX_CONTEXT_SIZE = 8192;


### PR DESCRIPTION
## Summary
- Adds Mercury 2 from Inception Labs as a second AI provider alongside OpenAI, using Mercury's OpenAI-compatible API with a custom `baseURL`
- Settings page now has a provider selector (OpenAI / Mercury) with per-provider API key management and automatic localStorage migration
- Process form filters models and tasks by provider — Mercury only supports text generation, so image/vision/speech/transcription tasks are disabled
- API routes (`/api/generate`, `/api/autodataset`) read the `x-ai-provider` header to construct the correct client, with backwards-compatible support for the legacy `x-openai-api-key` header

## Test plan
- [ ] Settings: select Mercury provider, enter Inception API key, save → verify localStorage stores provider + key
- [ ] Process form: select a Mercury model → verify only text-generation task is available
- [ ] Generate cells: create a text-generation column with mercury-2, generate rows → verify cells populate
- [ ] Switch back to OpenAI: change provider, enter OpenAI key → verify OpenAI models and all tasks work
- [ ] AutoDataset: create an auto-dataset with Mercury selected → verify config generation and cell population

🤖 Generated with [Claude Code](https://claude.com/claude-code)