### PR TITLE
Add spreadsheet-style cell editing and keyboard navigation

### DIFF
--- a/src/components/table/editable-cell.tsx
+++ b/src/components/table/editable-cell.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { CellRenderer } from './cell-renderer';
+import { useUIStore } from '@/lib/store/ui-store';
+import { useDatasetStore } from '@/lib/store/dataset-store';
+import { upsertCellValue } from '@/lib/supabase/queries/cells';
+import { createClient } from '@/lib/supabase/client';
+import { toast } from 'sonner';
+import type { TaskType } from '@/lib/types/domain';
+
+export function EditableCell({
+  columnId,
+  rowIdx,
+  value,
+  type,
+  generating,
+  error,
+  task,
+  datasetId,
+}: {
+  columnId: string;
+  rowIdx: number;
+  value: any;
+  type: string;
+  generating?: boolean;
+  error?: string;
+  task?: TaskType;
+  datasetId: string;
+}) {
+  const isFocused = useUIStore(
+    (s) => s.focusedCell?.columnId === columnId && s.focusedCell?.rowIdx === rowIdx,
+  );
+  const isEditing = useUIStore(
+    (s) => s.editingCell?.columnId === columnId && s.editingCell?.rowIdx === rowIdx,
+  );
+  const setFocusedCell = useUIStore((s) => s.setFocusedCell);
+  const setEditingCell = useUIStore((s) => s.setEditingCell);
+  const updateCell = useDatasetStore((s) => s.updateCell);
+
+  const [localValue, setLocalValue] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Seed local value when entering edit mode
+  useEffect(() => {
+    if (isEditing) {
+      setLocalValue(value != null ? String(value) : '');
+      // Focus textarea on next tick after render
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    }
+  }, [isEditing, value]);
+
+  const enterEdit = useCallback(() => {
+    setFocusedCell({ columnId, rowIdx });
+    setEditingCell({ columnId, rowIdx });
+  }, [columnId, rowIdx, setFocusedCell, setEditingCell]);
+
+  const cancelEdit = useCallback(() => {
+    setEditingCell(null);
+  }, [setEditingCell]);
+
+  const saveEdit = useCallback(async () => {
+    setEditingCell(null);
+    const trimmed = localValue.trim();
+    const newValue = trimmed === '' ? null : trimmed;
+
+    // Skip if unchanged
+    if (newValue === (value != null ? String(value) : null)) return;
+
+    // Optimistic update
+    updateCell(columnId, { row_idx: rowIdx, value: newValue, generating: false, validated: false });
+
+    try {
+      const supabase = createClient();
+      await upsertCellValue(supabase, {
+        dataset_id: datasetId,
+        column_id: columnId,
+        row_idx: rowIdx,
+        value: newValue,
+      });
+    } catch (err) {
+      toast.error('Failed to save cell');
+      // Revert optimistic update
+      updateCell(columnId, { row_idx: rowIdx, value, generating: false, validated: false });
+    }
+  }, [localValue, value, columnId, rowIdx, datasetId, updateCell, setEditingCell]);
+
+  const handleClick = useCallback(() => {
+    if (!isEditing) {
+      setFocusedCell({ columnId, rowIdx });
+    }
+  }, [isEditing, columnId, rowIdx, setFocusedCell]);
+
+  const handleDoubleClick = useCallback(() => {
+    enterEdit();
+  }, [enterEdit]);
+
+  const handleTextareaKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        cancelEdit();
+      } else if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        saveEdit();
+      }
+    },
+    [cancelEdit, saveEdit],
+  );
+
+  if (isEditing) {
+    return (
+      <textarea
+        ref={textareaRef}
+        value={localValue}
+        onChange={(e) => setLocalValue(e.target.value)}
+        onBlur={saveEdit}
+        onKeyDown={handleTextareaKeyDown}
+        className="w-full h-full resize-none bg-zinc-900 text-xs text-zinc-200 border border-blue-500 rounded px-1.5 py-1 outline-none"
+        rows={4}
+      />
+    );
+  }
+
+  return (
+    <div
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      className={`h-full cursor-default ${
+        isFocused ? 'ring-2 ring-blue-500/70 ring-inset rounded-sm' : ''
+      }`}
+    >
+      <CellRenderer
+        value={value}
+        type={type}
+        generating={generating}
+        error={error}
+        task={task}
+      />
+    </div>
+  );
+}

--- a/src/components/table/table-body.tsx
+++ b/src/components/table/table-body.tsx
@@ -1,8 +1,15 @@
 'use client';
 
-import { useRef } from 'react';
+import { useRef, useMemo, useCallback } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { CellRenderer } from './cell-renderer';
+import { EditableCell } from './editable-cell';
+import { useSpreadsheetKeyboard } from '@/hooks/use-spreadsheet-keyboard';
+import { useUIStore } from '@/lib/store/ui-store';
+import { useDatasetStore } from '@/lib/store/dataset-store';
+import { deleteCellValues } from '@/lib/supabase/queries/cells';
+import { createClient } from '@/lib/supabase/client';
+import { toast } from 'sonner';
+import { Plus, Trash2 } from 'lucide-react';
 import type { Column } from '@/lib/types/domain';
 
 const ROW_HEIGHT = 105;
@@ -18,6 +25,10 @@ export function TableBody({
   datasetId: string;
 }) {
   const parentRef = useRef<HTMLDivElement>(null);
+  const setRowCount = useDatasetStore((s) => s.setRowCount);
+  const clearRow = useDatasetStore((s) => s.clearRow);
+  const setFocusedCell = useUIStore((s) => s.setFocusedCell);
+  const setEditingCell = useUIStore((s) => s.setEditingCell);
 
   const virtualizer = useVirtualizer({
     count: Math.max(rowCount, 1),
@@ -26,7 +37,29 @@ export function TableBody({
     overscan: OVERSCAN,
   });
 
-  const visibleColumns = columns.filter((c) => c.visible);
+  const visibleColumns = useMemo(() => columns.filter((c) => c.visible), [columns]);
+  const visibleColumnIds = useMemo(() => visibleColumns.map((c) => c.id), [visibleColumns]);
+
+  useSpreadsheetKeyboard(parentRef, virtualizer, visibleColumnIds, rowCount, datasetId);
+
+  const handleAddRow = useCallback(() => {
+    setRowCount(rowCount + 1);
+  }, [rowCount, setRowCount]);
+
+  const handleClearRow = useCallback(
+    async (rowIdx: number) => {
+      clearRow(rowIdx);
+      setFocusedCell(null);
+      setEditingCell(null);
+      try {
+        const supabase = createClient();
+        await deleteCellValues(supabase, datasetId, [rowIdx]);
+      } catch {
+        toast.error('Failed to clear row');
+      }
+    },
+    [datasetId, clearRow, setFocusedCell, setEditingCell],
+  );
 
   if (visibleColumns.length === 0) {
     return (
@@ -39,12 +72,13 @@ export function TableBody({
   return (
     <div
       ref={parentRef}
-      className="h-[calc(100vh-3.5rem-3rem)]"
+      tabIndex={0}
+      className="h-[calc(100vh-3.5rem-3rem)] outline-none"
       style={{ overflow: 'auto' }}
     >
       <div
         style={{
-          height: `${virtualizer.getTotalSize()}px`,
+          height: `${virtualizer.getTotalSize() + ROW_HEIGHT}px`,
           width: '100%',
           position: 'relative',
         }}
@@ -58,9 +92,16 @@ export function TableBody({
               transform: `translateY(${virtualRow.start}px)`,
             }}
           >
-            {/* Row index */}
-            <div className="flex w-12 shrink-0 items-start justify-center border-r border-zinc-800/50 p-2 text-xs text-zinc-600 font-mono">
-              {virtualRow.index}
+            {/* Row index + clear button */}
+            <div className="group flex w-12 shrink-0 items-start justify-center border-r border-zinc-800/50 p-2 text-xs text-zinc-600 font-mono relative">
+              <span>{virtualRow.index}</span>
+              <button
+                onClick={() => handleClearRow(virtualRow.index)}
+                className="absolute top-1.5 right-0.5 hidden group-hover:flex items-center justify-center w-5 h-5 rounded text-zinc-500 hover:text-red-400 hover:bg-zinc-800"
+                title="Clear row"
+              >
+                <Trash2 className="w-3 h-3" />
+              </button>
             </div>
 
             {/* Cells */}
@@ -74,18 +115,37 @@ export function TableBody({
                   key={col.id}
                   className="w-56 shrink-0 border-r border-zinc-800/50 p-2 overflow-hidden"
                 >
-                  <CellRenderer
+                  <EditableCell
+                    columnId={col.id}
+                    rowIdx={virtualRow.index}
                     value={cell?.value}
                     type={col.type}
                     generating={cell?.generating}
                     error={cell?.error}
                     task={col.process?.task}
+                    datasetId={datasetId}
                   />
                 </div>
               );
             })}
           </div>
         ))}
+
+        {/* Add Row button — positioned after the last virtual row */}
+        <div
+          className="absolute left-0 top-0 flex w-full"
+          style={{
+            transform: `translateY(${virtualizer.getTotalSize()}px)`,
+          }}
+        >
+          <button
+            onClick={handleAddRow}
+            className="flex items-center gap-1.5 px-3 py-2 text-xs text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800/50 transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add Row
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/hooks/use-spreadsheet-keyboard.ts
+++ b/src/hooks/use-spreadsheet-keyboard.ts
@@ -1,0 +1,106 @@
+import { useCallback, useEffect } from 'react';
+import { useUIStore } from '@/lib/store/ui-store';
+import { useDatasetStore } from '@/lib/store/dataset-store';
+import { upsertCellValue } from '@/lib/supabase/queries/cells';
+import { createClient } from '@/lib/supabase/client';
+import type { Virtualizer } from '@tanstack/react-virtual';
+
+export function useSpreadsheetKeyboard(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  virtualizer: Virtualizer<HTMLDivElement, Element>,
+  visibleColumnIds: string[],
+  rowCount: number,
+  datasetId: string,
+) {
+  const focusedCell = useUIStore((s) => s.focusedCell);
+  const editingCell = useUIStore((s) => s.editingCell);
+  const setFocusedCell = useUIStore((s) => s.setFocusedCell);
+  const setEditingCell = useUIStore((s) => s.setEditingCell);
+  const updateCell = useDatasetStore((s) => s.updateCell);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      // No-op while editing — textarea handles its own keys
+      if (editingCell) return;
+      if (!focusedCell) return;
+
+      const colIdx = visibleColumnIds.indexOf(focusedCell.columnId);
+      if (colIdx === -1) return;
+
+      const move = (newColIdx: number, newRowIdx: number) => {
+        const clampedRow = Math.max(0, Math.min(rowCount - 1, newRowIdx));
+        const clampedCol = Math.max(0, Math.min(visibleColumnIds.length - 1, newColIdx));
+        setFocusedCell({ columnId: visibleColumnIds[clampedCol], rowIdx: clampedRow });
+        virtualizer.scrollToIndex(clampedRow);
+      };
+
+      switch (e.key) {
+        case 'ArrowUp':
+          e.preventDefault();
+          move(colIdx, focusedCell.rowIdx - 1);
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          move(colIdx, focusedCell.rowIdx + 1);
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          move(colIdx - 1, focusedCell.rowIdx);
+          break;
+        case 'ArrowRight':
+          e.preventDefault();
+          move(colIdx + 1, focusedCell.rowIdx);
+          break;
+        case 'Tab': {
+          e.preventDefault();
+          const dir = e.shiftKey ? -1 : 1;
+          let nextCol = colIdx + dir;
+          let nextRow = focusedCell.rowIdx;
+          if (nextCol >= visibleColumnIds.length) {
+            nextCol = 0;
+            nextRow++;
+          } else if (nextCol < 0) {
+            nextCol = visibleColumnIds.length - 1;
+            nextRow--;
+          }
+          move(nextCol, nextRow);
+          break;
+        }
+        case 'Enter':
+        case 'F2':
+          e.preventDefault();
+          setEditingCell({ columnId: focusedCell.columnId, rowIdx: focusedCell.rowIdx });
+          break;
+        case 'Delete':
+        case 'Backspace': {
+          e.preventDefault();
+          // Clear the focused cell value
+          updateCell(focusedCell.columnId, {
+            row_idx: focusedCell.rowIdx,
+            value: null,
+            generating: false,
+            validated: false,
+          });
+          const supabase = createClient();
+          upsertCellValue(supabase, {
+            dataset_id: datasetId,
+            column_id: focusedCell.columnId,
+            row_idx: focusedCell.rowIdx,
+            value: null,
+          }).catch(() => {
+            // silent — realtime will reconcile
+          });
+          break;
+        }
+      }
+    },
+    [focusedCell, editingCell, visibleColumnIds, rowCount, datasetId, setFocusedCell, setEditingCell, updateCell, virtualizer],
+  );
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener('keydown', handleKeyDown);
+    return () => el.removeEventListener('keydown', handleKeyDown);
+  }, [containerRef, handleKeyDown]);
+}

--- a/src/lib/store/dataset-store.ts
+++ b/src/lib/store/dataset-store.ts
@@ -20,6 +20,7 @@ interface DatasetState {
   updateCell: (columnId: string, cell: Cell) => void;
   setCellsForColumn: (columnId: string, cells: Cell[]) => void;
   mergeCells: (columnId: string, cells: Cell[]) => void;
+  clearRow: (rowIdx: number) => void;
 }
 
 export const useDatasetStore = create<DatasetState>((set) => ({
@@ -92,5 +93,13 @@ export const useDatasetStore = create<DatasetState>((set) => ({
           ),
         };
       }),
+    })),
+
+  clearRow: (rowIdx) =>
+    set((state) => ({
+      columns: state.columns.map((col) => ({
+        ...col,
+        cells: col.cells.filter((c) => c.row_idx !== rowIdx),
+      })),
     })),
 }));

--- a/src/lib/store/ui-store.ts
+++ b/src/lib/store/ui-store.ts
@@ -1,15 +1,21 @@
 import { create } from 'zustand';
 
+export type CellPosition = { columnId: string; rowIdx: number } | null;
+
 interface UIState {
   sidebarOpen: boolean;
   selectedColumnId: string | null;
   isGenerating: boolean;
   generatingColumnId: string | null;
+  focusedCell: CellPosition;
+  editingCell: CellPosition;
 
   setSidebarOpen: (open: boolean) => void;
   setSelectedColumnId: (id: string | null) => void;
   setIsGenerating: (generating: boolean) => void;
   setGeneratingColumnId: (id: string | null) => void;
+  setFocusedCell: (cell: CellPosition) => void;
+  setEditingCell: (cell: CellPosition) => void;
 }
 
 export const useUIStore = create<UIState>((set) => ({
@@ -17,9 +23,13 @@ export const useUIStore = create<UIState>((set) => ({
   selectedColumnId: null,
   isGenerating: false,
   generatingColumnId: null,
+  focusedCell: null,
+  editingCell: null,
 
   setSidebarOpen: (open) => set({ sidebarOpen: open }),
   setSelectedColumnId: (id) => set({ selectedColumnId: id, sidebarOpen: !!id }),
   setIsGenerating: (generating) => set({ isGenerating: generating }),
   setGeneratingColumnId: (id) => set({ generatingColumnId: id }),
+  setFocusedCell: (cell) => set({ focusedCell: cell }),
+  setEditingCell: (cell) => set({ editingCell: cell }),
 }));


### PR DESCRIPTION
## Summary
- Adds inline cell editing with double-click/Enter to edit, Escape to cancel, and Enter to save (with optimistic updates and Supabase persistence)
- Implements spreadsheet keyboard navigation (arrow keys, Tab/Shift+Tab, Delete/Backspace to clear cells)
- Adds row management: "Add Row" button and hover-to-reveal "Clear Row" action per row
- Extends UI and dataset stores with focused/editing cell state and a `clearRow` action

## Test plan
- [ ] Click a cell to focus it (blue ring), double-click or press Enter to edit
- [ ] Arrow keys, Tab, and Shift+Tab navigate between cells
- [ ] Delete/Backspace clears the focused cell value
- [ ] Editing a cell and pressing Enter saves; Escape cancels
- [ ] Hover over a row number to reveal the trash icon; clicking it clears the row
- [ ] "Add Row" button at the bottom appends a new row

🤖 Generated with [Claude Code](https://claude.com/claude-code)