### PR TITLE
Fix Add Column button hidden after first column

### DIFF
--- a/src/components/table/add-column-button.tsx
+++ b/src/components/table/add-column-button.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { toast } from 'sonner';
 import type { ColumnKind } from '@/lib/types/domain';
 
 export function AddColumnButton({ datasetId }: { datasetId: string }) {
@@ -50,7 +51,13 @@ export function AddColumnButton({ datasetId }: { datasetId: string }) {
       .select()
       .single();
 
-    if (!error && data) {
+    if (error) {
+      toast.error(error.message || 'Failed to add column');
+      setLoading(false);
+      return;
+    }
+
+    if (data) {
       addColumn({
         id: data.id,
         dataset_id: data.dataset_id,

--- a/src/components/table/spreadsheet.tsx
+++ b/src/components/table/spreadsheet.tsx
@@ -9,7 +9,6 @@ import { createClient } from '@/lib/supabase/client';
 import { TableHeader } from './table-header';
 import { TableBody } from './table-body';
 import { ProcessForm } from '@/components/sidebar/process-form';
-import { AddColumnButton } from './add-column-button';
 import type { Dataset, Column, Cell } from '@/lib/types/domain';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
@@ -186,7 +185,6 @@ export function Spreadsheet({
               rowCount={rowCount}
               datasetId={dataset.id}
             />
-            <AddColumnButton datasetId={dataset.id} />
           </div>
         </div>
 

--- a/src/components/table/table-header.tsx
+++ b/src/components/table/table-header.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { AddColumnButton } from './add-column-button';
 import type { Column } from '@/lib/types/domain';
 
 export function TableHeader({
@@ -98,6 +99,11 @@ export function TableHeader({
           </DropdownMenu>
         </div>
       ))}
+
+      {/* Add column button — always visible in header row */}
+      <div className="flex shrink-0 items-center border-r border-zinc-800 bg-zinc-950">
+        <AddColumnButton datasetId={datasetId} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Move `AddColumnButton` from below `TableBody` into the `TableHeader` flex row so it remains visible after columns are added (previously clipped by `overflow-hidden`)
- Add `toast.error` feedback when the Supabase column insert fails (errors were silently swallowed)

## Test plan
- [ ] Navigate to a dataset, add a first column — button should work
- [ ] Add a second and third column — button remains visible in the header row
- [ ] Refresh the page — all columns persist
- [ ] Verify button styling fits naturally in the header row

🤖 Generated with [Claude Code](https://claude.com/claude-code)