### PR TITLE
Fix LLM cell population with {{ColumnName}} variable references

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -67,6 +67,16 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  console.log('[generate] request', {
+    dataset_id,
+    column_id,
+    task: proc.task,
+    model: proc.model,
+    refs: proc.columns_references?.length ?? 0,
+    offset,
+    limit,
+  });
+
   const openai = createOpenAIClient(apiKey, baseURL);
 
   const encoder = new TextEncoder();
@@ -118,12 +128,15 @@ export async function POST(request: NextRequest) {
 
                 // Save the result
                 if (result.value !== undefined) {
+                  console.log('[generate] cell success', { row: rowIdx, valueLen: String(result.value).length });
                   await upsertCellValue(supabase, {
                     dataset_id,
                     column_id,
                     row_idx: rowIdx,
                     value: result.value,
                   });
+                } else if (result.error) {
+                  console.warn('[generate] cell error', { row: rowIdx, error: result.error });
                 }
 
                 await upsertCellMeta(supabase, {
@@ -202,15 +215,37 @@ async function generateSingleCell({
   if (hasRefs) {
     const rowCells = await getRowCells(
       supabase,
+      dataset_id,
       rowIdx,
       proc.columns_references!,
     );
+
+    console.log('[generate] getRowCells', {
+      row: rowIdx,
+      cellsReturned: rowCells?.length ?? 0,
+    });
 
     if (rowCells && rowCells.length > 0) {
       data = Object.fromEntries(
         rowCells.map((cell: any) => [cell.columns?.name || cell.column_id, cell.value]),
       );
     }
+
+    // Validate that all referenced template variables have data
+    const refRegex = /\{\{([^}]+)\}\}/g;
+    let refMatch: RegExpExecArray | null;
+    const expectedVars: string[] = [];
+    while ((refMatch = refRegex.exec(proc.prompt)) !== null) {
+      expectedVars.push(refMatch[1].trim());
+    }
+    const missingVars = expectedVars.filter((v) => !(v in data) || data[v] == null || data[v] === '');
+    if (missingVars.length > 0) {
+      const msg = `Missing data for column(s) '${missingVars.join("', '")}' at row ${rowIdx}. Populate the referenced column(s) first.`;
+      console.warn('[generate]', msg);
+      return { error: msg };
+    }
+
+    console.log('[generate] data context', { row: rowIdx, columns: Object.keys(data) });
   }
 
   switch (proc.task) {
@@ -226,7 +261,7 @@ async function generateSingleCell({
       if (!proc.image_column_id) {
         return { error: 'No image column configured for vision task' };
       }
-      const imageCells = await getRowCells(supabase, rowIdx, [
+      const imageCells = await getRowCells(supabase, dataset_id, rowIdx, [
         proc.image_column_id,
       ]);
       const imageUrl = imageCells?.[0]?.value;
@@ -257,7 +292,7 @@ async function generateSingleCell({
       if (!proc.image_column_id) {
         return { error: 'No audio column configured for transcription' };
       }
-      const audioCells = await getRowCells(supabase, rowIdx, [
+      const audioCells = await getRowCells(supabase, dataset_id, rowIdx, [
         proc.image_column_id,
       ]);
       const audioData = audioCells?.[0]?.value;

--- a/src/components/sidebar/process-form.tsx
+++ b/src/components/sidebar/process-form.tsx
@@ -143,7 +143,7 @@ export function ProcessForm({
 
     if (error) {
       toast.error('Failed to save process config');
-      return;
+      return false;
     }
 
     if (data) {
@@ -173,6 +173,7 @@ export function ProcessForm({
     });
 
     toast.success('Process saved');
+    return true;
   };
 
   const handleGenerate = async () => {
@@ -181,7 +182,8 @@ export function ProcessForm({
       return;
     }
 
-    await handleSave();
+    const saved = await handleSave();
+    if (!saved) return;
 
     setGenerating(true);
     setIsGenerating(true);
@@ -194,6 +196,19 @@ export function ProcessForm({
       const refName = m[1].trim();
       const refCol = columns.find((c) => c.name === refName);
       if (refCol) refs.push(refCol.id);
+    }
+
+    // Warn if referenced columns appear to have no data
+    if (refs.length > 0) {
+      const storeState = useDatasetStore.getState();
+      for (const refId of refs) {
+        const refCol = columns.find((c) => c.id === refId);
+        const refCells = storeState.cells[refId];
+        const hasCells = refCells && Object.keys(refCells).length > 0;
+        if (!hasCells && refCol) {
+          toast.warning(`Column '${refCol.name}' has no data. Results may be incomplete.`);
+        }
+      }
     }
 
     try {
@@ -272,13 +287,17 @@ export function ProcessForm({
             if (data.event === 'generation.error') {
               toast.error(data.error);
             }
-          } catch {
-            // skip malformed SSE
+          } catch (parseErr) {
+            console.warn('[generate] malformed SSE line:', line, parseErr);
           }
         }
       }
 
-      toast.success('Generated ' + completedCount + ' cells');
+      if (completedCount === 0) {
+        toast.warning('No cells were generated. Check that referenced columns have data.');
+      } else {
+        toast.success('Generated ' + completedCount + ' cells');
+      }
     } catch (err) {
       toast.error(
         err instanceof Error ? err.message : 'Generation failed',

--- a/src/lib/supabase/queries/cells.ts
+++ b/src/lib/supabase/queries/cells.ts
@@ -94,6 +94,7 @@ export async function getRowCount(
 
 export async function getRowCells(
   supabase: SupabaseClient,
+  datasetId: string,
   rowIdx: number,
   columnIds: string[],
 ) {
@@ -102,6 +103,7 @@ export async function getRowCells(
   const { data, error } = await supabase
     .from('cell_values')
     .select('*, columns!inner(name)')
+    .eq('dataset_id', datasetId)
     .in('column_id', columnIds)
     .eq('row_idx', rowIdx);
 


### PR DESCRIPTION
## Summary

- **Fixed `getRowCells` missing `dataset_id` filter** — queries now scope to the correct dataset, preventing cross-dataset cell pollution
- **Added server-side validation for template variables** — if a referenced column has no data at a given row, the API returns a clear error instead of sending a broken prompt to the LLM
- **Added logging throughout the generation API** — request params, query results, and per-cell success/error are now logged for diagnostics
- **Improved client-side error surfacing** — `handleSave` failures now abort generation, empty referenced columns trigger warning toasts before generation starts, zero-cell results show a warning, and malformed SSE lines are logged

## Test plan

- [ ] Create a dataset with a static column ("Name") and a dynamic column ("Story") using `{{Name}}` references
- [ ] Populate the Name column, configure Story with a prompt like "Write a story about {{Name}}", and click Generate
- [ ] Verify cells populate with correct per-row values
- [ ] Test with an empty referenced column and confirm warning toast appears
- [ ] Check server logs for `[generate]` diagnostic output

🤖 Generated with [Claude Code](https://claude.com/claude-code)